### PR TITLE
PHPCS/Composer: update PHPCompatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ install:
     - composer update $COMPOSER_FLAGS
 
 script:
-    - ./vendor/bin/phpcs --standard=ruleset.xml -p -n
+    - ./vendor/bin/phpcs -n
     - phpunit

--- a/composer.json
+++ b/composer.json
@@ -23,21 +23,12 @@
       "symfony/serializer": "~2.8|~3.0|^4.0"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^2.5",
         "escapestudios/symfony2-coding-standard": "^2.9",
-        "wimg/php-compatibility": "^7.0"
+        "phpcompatibility/php-compatibility": "^9.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
     },
     "scripts": {
-        "default-scripts": [
-            "rm -rf vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility; cp -rp vendor/wimg/php-compatibility vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility"
-        ],
-        "post-install-cmd": [
-            "@default-scripts"
-        ],
-        "post-update-cmd": [
-            "@default-scripts"
-        ],
         "test": "phpunit",
-        "cs": "phpcs --standard=ruleset.xml -p"
+        "cs": "phpcs"
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,10 +6,10 @@
     <exclude-pattern>Resources/</exclude-pattern>
     <exclude-pattern>tests/</exclude-pattern>
 
-    <rule ref="vendor/escapestudios/symfony2-coding-standard/Symfony2"/>
-    <rule ref="vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility" />
+    <rule ref="Symfony2"/>
+    <rule ref="PHPCompatibility" />
 
-    <config name="testVersion" value="5.5-7.0"/>
+    <config name="testVersion" value="5.5-"/>
 
     <rule ref="PEAR.Functions.ValidDefaultValue.NotAtEnd">
         <severity>0</severity>


### PR DESCRIPTION
Composer:
* `wimg/php-compatibility` has been abandoned for nearly a year. Use `phpcompatibility/php-compatibility` instead.
* Use the latest version of PHPCompatibility.
    You were missing out on a lot of new checks, including the checks to make sure your code is compatible with the upcoming PHP 7.4.
* Remove the `squizlabs/php_codesniffer` dependency.
    This is not _your_ dependency, but a dependency of the SymfonyCS and the PHPCompatibility packages, so let them negotiate the version of PHPCS to use.
* Add the DealerDirect Composer PHPCS plugin.
    This plugin will handle setting the PHPCS `installed_paths` automatically.
    This also allows for removing the outdated scripts from the Composer file, as well as referencing the rulesets by name instead of via the path in the ruleset, which is generally more stable.

PHPCS ruleset:
* Rename the ruleset to `phpcs.xml.dist` which will allow PHPCS to automatically pick up on it.
    No need to pass the `--standard=...` command-line argument anymore.
    Includes removing the argument from the Travis and the Composer script.
* Check for cross-version compatibility for the minimum PHP version and up.
    PHPCompatibility _was_ checking against PHP 5.5 up to PHP 7.0.
    The new `testVersion` actually checks against PHP 5.5 up to the latest version (upcoming 7.4 at this moment).

Refs:
* https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions
* https://github.com/PHPCompatibility/PHPCompatibility/releases/
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer

Please also consider updating the SymfonyCS package.